### PR TITLE
Raspberry Pi builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,32 @@ To update the Linux dynamic libs (names will be different on other platfroms):
     rm raylib/dynamic/*.so*
     cp -P /usr/local/lib/libraylib.so* raylib/dynamic/
 
+### Raspberry Pi
+
+The integrated GPU hardware in a Raspberry Pi ("VideoCore") is rather
+idiosyncratic, resulting in a complex set of software options. Probably the
+most interesting two options for Raylib applications are:
+
+ 1. Use the Broadcom proprietary Open GL ES 2.0 drivers, installed by Raspbian
+    into `/opt/vc`. These are 32-bit only, and currently X11 doesn't use these
+    for its acceleration, so this is most suitable for driving the entire HDMI
+    output from one application with minimal overhead (no X11).
+
+ 2. Use the more recent open-source `vc4-fkms-v3d` kernel driver. This can run
+    in either 32-bit or 64-bit, and X11 can use these, so using X11 is probably
+    the more common choice here.
+
+With option 2, the regular linux install instructions above should probably
+work as-is.
+
+For option 1, then also follow the above instructions, but with these
+modifications:
+
+ - With `cmake`, use `cmake -DWITH_PIC=on -DSTATIC=on -DSHARED=on -DPLATFORM='Raspberry Pi' ..`
+ - Use `python3 build_rpi_nox.py` instead of `python3 build_linux.py`
+ - Use `build_rpi_nox_multi.sh` to build a complete set of libs if you need it
+   (if you're not sure, then you almost certainly don't).
+
 # Use
 
 ## raylib.static

--- a/raylib/static/build_rpi_nox.py
+++ b/raylib/static/build_rpi_nox.py
@@ -1,0 +1,26 @@
+# Raspberry Pi native (non-X) build assumes the GPU libraries are installed in /opt/vc, as per Raspbian.
+# Raylib must be installed the compiled with:  cmake -DWITH_PIC=ON -DSHARED=ON -DSTATIC=ON -DPLATFORM='Raspberry Pi' ..
+
+from cffi import FFI
+import os
+import platform
+ffibuilder = FFI()
+
+
+ffibuilder.cdef(open("../raylib_modified.h").read().replace('RLAPI ', ''))
+
+
+ffibuilder.set_source("_raylib_cffi",
+                      """
+                           #include "../raylib.h"
+                      """,
+                      extra_link_args=['/usr/local/lib/libraylib.a',
+                                       '/opt/vc/lib/libEGL_static.a', '/opt/vc/lib/libGLESv2_static.a',
+                                       '-L/opt/vc/lib', '-lvcos', '-lbcm_host', '-lbrcmEGL', '-lbrcmGLESv2',
+                                       '-lm', '-lpthread', '-lrt'],
+                      )
+
+
+if __name__ == "__main__":
+    ffibuilder.compile(verbose=True)
+

--- a/raylib/static/build_rpi_nox_multi.sh
+++ b/raylib/static/build_rpi_nox_multi.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+if ! command -v pyenv &> /dev/null
+then
+    echo "Pyenv required: https://github.com/pyenv/pyenv-installer"
+    exit
+fi
+rm *arm-linux-gnueabihf.so
+pyenv install -s 3.9.1
+pyenv global 3.9.1
+pip3 install cffi
+python3 build_rpi_nox.py
+pyenv install -s 3.8.7
+pyenv global 3.8.7
+pip3 install cffi
+python3 build_rpi_nox.py
+pyenv install -s 3.7.9
+pyenv global 3.7.9
+pip3 install cffi
+python3 build_rpi_nox.py
+pyenv install -s 3.6.12
+pyenv global 3.6.12
+pip3 install cffi
+python3 build_rpi_nox.py


### PR DESCRIPTION
Thanks for this project!

This partially addresses #26, but doesn't commit the `.so` binaries. This is because, as the README diff explains, there is more than one way to use Raylib on a Raspberry Pi, and a single shared object has to chose one.

I've tested this using the first option listed there (32-bit Broadcom GPU drivers, full-screen application, no X11) and it works great.