### PR TITLE
Fix dynamic raylib loading on Windows

### DIFF
--- a/dynamic/raylib/__init__.py
+++ b/dynamic/raylib/__init__.py
@@ -37,7 +37,7 @@ def raylib_library_path():
     def so_name():
         '''Returns the appropriate for the library on the current platform.'''
         lib_filenames = {
-            'Windows': 'libraylib.dll',
+            'Windows': 'raylib.dll',
             'Linux': 'libraylib.so',
             'Darwin': 'libraylib.dylib',
         }


### PR DESCRIPTION
Library name on Windows is different. 
I could rename library, but name.dll on windows is more appropriate that libname.dll, I guess, so I've fixed expected library name in init module.

Some fragments of debugging:
```
➜ tanki git:(main) python
Python 3.9.4 (tags/v3.9.4:1f2e308, Apr  6 2021, 13:40:21) [MSC v.1928 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import raylib
cannot load library 'C:\Users\most\proj\tanki\.venv\lib\site-packages\raylib\libraylib.dll': error 0x7e.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'C:\\Users\\most\\proj\\tanki\\.venv\\lib\\site-packages\\raylib\\libraylib.dll'
>>> exit()

➜ tanki git:(main) mv C:\Users\most\proj\tanki\.venv\lib\site-packages\raylib\raylib.dll C:\Users\most\proj\tanki\.venv\lib\site-packages\raylib\libraylib.dll

➜ tanki git:(main) python
Python 3.9.4 (tags/v3.9.4:1f2e308, Apr  6 2021, 13:40:21) [MSC v.1928 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import raylib
LOADED DYNAMICALLY SHARED LIB 3.7.0.post10 C:\Users\most\proj\tanki\.venv\lib\site-packages\raylib\libraylib.dll
>>>
```