### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/create_stub_pyray.py
+++ b/create_stub_pyray.py
@@ -33,28 +33,27 @@ for filename in (Path("raylib.json"), Path("raymath.json"), Path("rlgl.json"), P
 def ctype_to_python_type(t):
     if t == '_Bool':
         return "bool"
-    elif t == 'void':
+    if t == 'void':
         return 'None'
-    elif t == "long":
+    if t == "long":
         return "int"
-    elif t == "unsigned long long":
+    if t == "unsigned long long":
         return "int"
-    elif t == "double":
+    if t == "double":
         return "float"
-    elif "char * *" in t:
+    if "char * *" in t:
         return "list[str]"
-    elif "char *" in t:
+    if "char *" in t:
         return "str"
-    elif "char" in t:
+    if "char" in t:
         return "str"  # not sure about this one
-    elif "*" in t:
+    if "*" in t:
         return "Any"
-    elif t.startswith("struct"):
+    if t.startswith("struct"):
         return t.replace("struct ","")
-    elif t.startswith("unsigned"):
+    if t.startswith("unsigned"):
         return t.replace("unsigned ", "")
-    else:
-        return t
+    return t
 
 print("""from typing import Any
 

--- a/create_stub_static.py
+++ b/create_stub_static.py
@@ -34,26 +34,25 @@ for filename in (Path("raylib.json"), Path("raymath.json"), Path("rlgl.json"), P
 def ctype_to_python_type(t):
     if t == '_Bool':
         return "bool"
-    elif t == 'void':
+    if t == 'void':
         return 'None'
-    elif t == "long":
+    if t == "long":
         return "int"
-    elif t == "unsigned long long":
+    if t == "unsigned long long":
         return "int"
-    elif t == "double":
+    if t == "double":
         return "float"
-    elif "char *" in t:
+    if "char *" in t:
         return "str"
-    elif "char" in t:
+    if "char" in t:
         return "str"  # not sure about this one
-    elif "*" in t:
+    if "*" in t:
         return "Any"
-    elif t.startswith("struct"):
+    if t.startswith("struct"):
         return t.replace("struct ","")
-    elif t.startswith("unsigned"):
+    if t.startswith("unsigned"):
         return t.replace("unsigned ", "")
-    else:
-        return t
+    return t
 
 
 print("""from typing import Any

--- a/pyray/__init__.py
+++ b/pyray/__init__.py
@@ -82,15 +82,12 @@ def _wrap_function(original_func):
         result = original_func(*modified_args)
         if result is None:
             return
-        elif is_cdata(result) and str(result).startswith("<cdata 'char *'"):
+        if is_cdata(result) and str(result).startswith("<cdata 'char *'"):
             if str(result) == "<cdata 'char *' NULL>":
                 return ""
-            else:
-                return ffi.string(result).decode('utf-8')
-        else:
-            return result
+            return ffi.string(result).decode('utf-8')
+        return result
 
-    # apparently pypy and cpython produce different types so check for both
     def is_cdata(arg):
         return str(type(arg)) == "<class '_cffi_backend.__CDataOwn'>" or str(
             type(arg)) == "<class '_cffi_backend._CDataBase'>"


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.