### PR TITLE
Fix physics example

### DIFF
--- a/examples/physics/physac.py
+++ b/examples/physics/physac.py
@@ -25,10 +25,10 @@ SetTargetFPS(60)
 while not WindowShouldClose():
     # Update
     # ----------------------------------------------------------------------
-    UpdatePhysics()  # Update physics system
 
     if IsKeyPressed(KEY_R):  # Reset physics system
-        ResetPhysics()
+        ClosePhysics()
+        InitPhysics()
 
         floor = CreatePhysicsBodyRectangle((SCREEN_WIDTH/2, SCREEN_HEIGHT), 500, 100, 10)
         floor.enabled = False


### PR DESCRIPTION
I was playing around with the library (thanks for publishing, BTW) and noticed that physac.py example wasn't working well, because "UpdatePhysics" function was not defined:

```
Traceback (most recent call last):
  File "/home/max/Projects/Projects/Dichronauts/raylib/physac.py", line 27, in <module>
    UpdatePhysics()  # TODO no longer works
    ^^^^^^^^^^^^^
NameError: name 'UpdatePhysics' is not defined
```

So I just commented it out and to my surprise it worked well :D

I digged a bit deeper to try to figure out what happened and realized that it seems like physac was updated (to v1.1) since initial bindings were created.
It still has InitPhysics, but now it seems to include it's own, so you don't need to call UpdatePhysics anymore.
ResetPhysics was removed, but nobody stops you to `ClosePhysics(); InitPhysics()` to the same effect.

That's what I did and now it works as expected:
![Screenshot from 2025-04-14 17-46-55](https://github.com/user-attachments/assets/09034b07-fe8a-4217-a319-41b35feea62b)
