### PR TITLE
feat: add Python version of core_basic_window from raylib

### DIFF
--- a/examples/contrib/core_basic_window.py
+++ b/examples/contrib/core_basic_window.py
@@ -1,0 +1,11 @@
+import pyray
+
+pyray.init_window(800, 450, b"Hello Raylib [pyray]")
+
+while not pyray.window_should_close():
+    pyray.begin_drawing()
+    pyray.clear_background(pyray.RAYWHITE)
+    pyray.draw_text(b"Hello, world!", 190, 200, 20, pyray.DARKGRAY)
+    pyray.end_drawing()
+
+pyray.close_window()


### PR DESCRIPTION
This pull request adds the Python translation of the `core_basic_window` example from the original C version in raylib.  
The translated example creates a basic window using pyray and displays the "Hello, world!" text.

✅ Verified that it runs correctly on macOS using `python3 examples/contrib/core_basic_window.py`.

This contributes to expanding the pyray examples and helps Python developers get started with raylib.

Related to: https://github.com/overdrivenpotato/raylib-python-cffi/issues/173
