### PR TITLE
fix(ci): enable Wayland in linux Desktop wheel builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,7 +257,15 @@ jobs:
           cd raylib-c
           mkdir build
           cd build
-          cmake -DPLATFORM=${{ matrix.raylib-platform }} -DBUILD_EXAMPLES=OFF -DCUSTOMIZE_BUILD=ON -DSUPPORT_FILEFORMAT_JPG=ON -DSUPPORT_FILEFORMAT_FLAC=ON -DWITH_PIC=ON -DCMAKE_BUILD_TYPE=Release -DOpenGL_GL_PREFERENCE=GLVND ..
+          extra_cmake_args=""
+          if [ "${{ matrix.raylib-platform }}" = "Desktop" ]; then
+            apt-get update
+            apt-get install -y wayland-protocols
+            # Ubuntu 16 has an older wayland-scanner that expects "code" instead of "private-code".
+            sed -i 's/private-code/code/g' ../src/external/glfw/src/CMakeLists.txt
+            extra_cmake_args="-DGLFW_BUILD_WAYLAND=ON -DGLFW_BUILD_X11=ON"
+          fi
+          cmake -DPLATFORM=${{ matrix.raylib-platform }} -DBUILD_EXAMPLES=OFF -DCUSTOMIZE_BUILD=ON -DSUPPORT_FILEFORMAT_JPG=ON -DSUPPORT_FILEFORMAT_FLAC=ON -DWITH_PIC=ON -DCMAKE_BUILD_TYPE=Release -DOpenGL_GL_PREFERENCE=GLVND ${extra_cmake_args} ..
           make -j2
           make install
       - name: Copy extras
@@ -351,7 +359,15 @@ jobs:
           cd raylib-c
           mkdir build
           cd build
-          setarch i386 cmake -DPLATFORM=${{ matrix.raylib-platform }} -DBUILD_EXAMPLES=OFF -DCUSTOMIZE_BUILD=ON -DSUPPORT_FILEFORMAT_JPG=ON -DSUPPORT_FILEFORMAT_FLAC=ON -DWITH_PIC=ON -DCMAKE_BUILD_TYPE=Release -DOpenGL_GL_PREFERENCE=GLVND ..
+          extra_cmake_args=""
+          if [ "${{ matrix.raylib-platform }}" = "Desktop" ]; then
+            apt-get update
+            apt-get install -y wayland-protocols
+            # Ubuntu 16 has an older wayland-scanner that expects "code" instead of "private-code".
+            sed -i 's/private-code/code/g' ../src/external/glfw/src/CMakeLists.txt
+            extra_cmake_args="-DGLFW_BUILD_WAYLAND=ON -DGLFW_BUILD_X11=ON"
+          fi
+          setarch i386 cmake -DPLATFORM=${{ matrix.raylib-platform }} -DBUILD_EXAMPLES=OFF -DCUSTOMIZE_BUILD=ON -DSUPPORT_FILEFORMAT_JPG=ON -DSUPPORT_FILEFORMAT_FLAC=ON -DWITH_PIC=ON -DCMAKE_BUILD_TYPE=Release -DOpenGL_GL_PREFERENCE=GLVND ${extra_cmake_args} ..
           make -j2
           make install
       - name: Copy extras
@@ -430,7 +446,7 @@ jobs:
       - name: install libs
         run: |
           sudo apt update
-          sudo apt -y install cmake libasound2-dev mesa-common-dev libx11-dev libxrandr-dev libxi-dev xorg-dev libgl1-mesa-dev libglu1-mesa-dev libwayland-dev libxkbcommon-dev libgbm-dev libdrm-dev
+          sudo apt -y install cmake libasound2-dev mesa-common-dev libx11-dev libxrandr-dev libxi-dev xorg-dev libgl1-mesa-dev libglu1-mesa-dev libwayland-dev libxkbcommon-dev libgbm-dev libdrm-dev wayland-protocols
 
       - name: Build SDL
         run: |
@@ -455,7 +471,11 @@ jobs:
           cd raylib-c
           mkdir build2
           cd build2
-          cmake -DPLATFORM=${{ matrix.raylib-platform }}  -DBUILD_EXAMPLES=OFF -DCUSTOMIZE_BUILD=ON -DSUPPORT_FILEFORMAT_JPG=ON -DSUPPORT_FILEFORMAT_FLAC=ON -DWITH_PIC=ON -DCMAKE_BUILD_TYPE=Release ..
+          extra_cmake_args=""
+          if [ "${{ matrix.raylib-platform }}" = "Desktop" ]; then
+            extra_cmake_args="-DGLFW_BUILD_WAYLAND=ON -DGLFW_BUILD_X11=ON"
+          fi
+          cmake -DPLATFORM=${{ matrix.raylib-platform }}  -DBUILD_EXAMPLES=OFF -DCUSTOMIZE_BUILD=ON -DSUPPORT_FILEFORMAT_JPG=ON -DSUPPORT_FILEFORMAT_FLAC=ON -DWITH_PIC=ON -DCMAKE_BUILD_TYPE=Release ${extra_cmake_args} ..
           make -j2
           sudo make install
 


### PR DESCRIPTION
## Summary

This PR makes Linux **Desktop** wheels Wayland-capable by building raylib/GLFW with both Wayland and X11 backends enabled.

It addresses failures like:

`GLFW: Error: 65544 Description: X11: Failed to load Xlib`  
`GLFW: Failed to initialize GLFW`

on Wayland-only environments that do not have Xlib available.

## Root Cause

Current Linux Desktop wheel builds compile raylib with default GLFW options, which effectively produce X11-only Desktop artifacts for our published wheels.

For Linux jobs, we were building with `-DPLATFORM=Desktop` but without explicitly enabling `GLFW_BUILD_WAYLAND`.

There is also a builder-image compatibility issue:
- Our `ubuntu16-modern` manylinux builder has an older `wayland-scanner`.
- GLFW’s CMake currently uses `private-code`, which that older scanner does not support.
- Naively enabling Wayland fails in CI unless we handle this compatibility gap.

## What Changed

All changes are in the Linux wheel workflow (`.github/workflows/build.yml`).

### 1) Linux x86_64 Desktop wheels (`build-linux` job)
- For `raylib-platform == Desktop`:
- Install `wayland-protocols`.
- Apply a compatibility rewrite in bundled GLFW CMake: `private-code` -> `code`.
- Pass CMake flags: `-DGLFW_BUILD_WAYLAND=ON -DGLFW_BUILD_X11=ON`.

### 2) Linux i686 Desktop wheels (`build-linux32` job)
- Same Desktop-only changes as x86_64:
- Install `wayland-protocols`.
- Apply `private-code` -> `code` compatibility rewrite.
- Pass `-DGLFW_BUILD_WAYLAND=ON -DGLFW_BUILD_X11=ON`.

### 3) Linux arm64 Desktop wheels (`build-linux-arm64` job)
- Add `wayland-protocols` to apt packages.
- For `raylib-platform == Desktop`, pass:
  `-DGLFW_BUILD_WAYLAND=ON -DGLFW_BUILD_X11=ON`.

## Scope / Non-Goals

- No Python API changes.
- No runtime behavior changes outside backend availability.
- No changes to SDL/DRM packaging behavior.
- No changes to macOS or Windows wheel logic.

## Why This Is Safe

- Desktop Linux wheels still include X11 support.
- We are adding Wayland support, not replacing X11.
- Backend selection remains GLFW runtime behavior, so existing X11 users should continue to work unchanged.

## Validation

I validated this in the same legacy builder context used for manylinux Desktop wheels (`electronstudio/ubuntu16-modern`):

- Without compatibility handling, Wayland-enabled build fails due to old `wayland-scanner` and `private-code`.
- With this PR’s compatibility rewrite + flags, build succeeds.
- The resulting wheel’s `_raylib_cffi` binary contains both symbols:
  - `_glfwConnectWayland`
  - `_glfwConnectX11`

This confirms the artifact is dual-backend capable.

## Downstream Impact

This should unblock Wayland-only users (including `uvx` users of downstream apps that depend on `raylib`) without requiring distro/Nix-specific repackaging workarounds.

## Follow-up (optional)

Once the manylinux builder image is modernized, we can remove the temporary `private-code` compatibility rewrite and keep only explicit `GLFW_BUILD_WAYLAND=ON`.
